### PR TITLE
ALPACA-81 デバイストークンのエンドポイントの作成(CRD)

### DIFF
--- a/nestJS/src/device-token/device-token.controller.ts
+++ b/nestJS/src/device-token/device-token.controller.ts
@@ -1,8 +1,8 @@
 import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
 import { DeviceTokenPayload} from './interface/device-token.payload';
 import { DeviceTokenService } from './device-token.service';
-import { DeleteDeviceTokenInput } from './interface/delete-device-token.input';
-import { UpsertDeviceTokenInput } from './interface/upsert-device-token.input';
+import { DeviceTokenDeleteInput } from './interface/device-token-delete.input';
+import { DeviceTokenUpsertInput } from './interface/device-token-upsert.input';
 
 @Controller('device_token')
 export class DeviceTokenController {
@@ -13,14 +13,13 @@ export class DeviceTokenController {
         return await this.deviceTokenService.getAllDeviceToken();
     }
 
-    @Post('upsert')
-    async upsertDeviceToken(@Body() upsertDeviceToken:UpsertDeviceTokenInput,):Promise<string>{
-        console.log(upsertDeviceToken instanceof UpsertDeviceTokenInput,upsertDeviceToken)
-        return await this.deviceTokenService.upsertDeviceToken(upsertDeviceToken);
+    @Post('create')
+    async createDeviceToken(@Body() upsertDeviceToken:DeviceTokenUpsertInput,):Promise<string>{
+        return await this.deviceTokenService.createDeviceToken(upsertDeviceToken);
     }
 
     @Delete('delete')
-    async deleteDeviceToken(@Query() query:DeleteDeviceTokenInput):Promise<string>{
+    async deleteDeviceToken(@Query() query:DeviceTokenDeleteInput):Promise<string>{
         return await this.deviceTokenService.deleteDeviceToken(query);
     }
 }

--- a/nestJS/src/device-token/interface/device-token-delete.input.ts
+++ b/nestJS/src/device-token/interface/device-token-delete.input.ts
@@ -1,6 +1,6 @@
 import { IsString, IsNotEmpty } from "class-validator";
 
-export class DeleteDeviceTokenInput {
+export class DeviceTokenDeleteInput {
     @IsString()
     @IsNotEmpty()
     deviceToken:string;

--- a/nestJS/src/device-token/interface/device-token-upsert.input.ts
+++ b/nestJS/src/device-token/interface/device-token-upsert.input.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsOptional, IsString } from "class-validator";
 
-export class UpsertDeviceTokenInput {
+export class DeviceTokenUpsertInput {
     @IsString()
     @IsNotEmpty()
     deviceToken:string;


### PR DESCRIPTION
# 目的や背景
プッシュ通知を送るために、必要なデバイストークンを格納する
# 変更内容の概要
~/device_token/createと~/~/deleteと~/~/get_allを作成しました
# スクリーンショット

# 関連するリンク

# Staging 環境での動作確認チェックリスト

- [ ] ここに確認事項を記載
