### PR TITLE
db内のトークン全てにプッシュ通知を送るエンドポイントを作成

### DIFF
--- a/nestJS/src/common/chunkArray.ts
+++ b/nestJS/src/common/chunkArray.ts
@@ -1,0 +1,7 @@
+export const chunkArray = <T>(chunkSize: number): ((array: T[]) => T[][]) => {
+  return (array: any[]) => {
+    return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) =>
+      array.slice(i * chunkSize, (i + 1) * chunkSize),
+    );
+  };
+};

--- a/nestJS/src/common/chunkArray.ts
+++ b/nestJS/src/common/chunkArray.ts
@@ -1,5 +1,0 @@
-export const chunkArray = <T>(chunkSize: number, array: T[]): T[][] => {
-  return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) => {
-    return array.slice(i * chunkSize, (i + 1) * chunkSize);
-  });
-};

--- a/nestJS/src/common/chunkArray.ts
+++ b/nestJS/src/common/chunkArray.ts
@@ -1,7 +1,5 @@
-export const chunkArray = <T>(chunkSize: number): ((array: T[]) => T[][]) => {
-  return (array: any[]) => {
-    return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) =>
-      array.slice(i * chunkSize, (i + 1) * chunkSize),
-    );
-  };
+export const chunkArray = <T>(chunkSize: number, array: T[]): T[][] => {
+  return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) => {
+    return array.slice(i * chunkSize, (i + 1) * chunkSize);
+  });
 };

--- a/nestJS/src/device-token/device-token.controller.ts
+++ b/nestJS/src/device-token/device-token.controller.ts
@@ -3,6 +3,7 @@ import { DeviceTokenPayload } from './interface/device-token.payload';
 import { DeviceTokenService } from './device-token.service';
 import { DeviceTokenDeleteInput } from './interface/device-token-delete.input';
 import { DeviceTokenCreateInput } from './interface/device-token-create.input';
+import { PushNotificationInput } from './interface/push-notification.input';
 
 @Controller('device_token')
 export class DeviceTokenController {
@@ -18,6 +19,15 @@ export class DeviceTokenController {
     @Body() createDeviceToken: DeviceTokenCreateInput,
   ): Promise<string> {
     return await this.deviceTokenService.createDeviceToken(createDeviceToken);
+  }
+
+  @Post('push_notification')
+  async pushNotification(
+    @Body() pushNotificationInput: PushNotificationInput,
+  ): Promise<string> {
+    return await this.deviceTokenService.pushNotification(
+      pushNotificationInput,
+    );
   }
 
   @Delete('delete')

--- a/nestJS/src/device-token/device-token.service.ts
+++ b/nestJS/src/device-token/device-token.service.ts
@@ -11,7 +11,6 @@ import { validateValue } from 'src/common/validate-value';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PushNotificationInput } from './interface/push-notification.input';
 import { ExpoPushPayload } from './interface/expo-push.payload';
-import { chunkArray } from 'src/common/chunkArray';
 
 const MAX_TOKENS_PER_REQUEST = 100;
 
@@ -51,7 +50,7 @@ export class DeviceTokenService {
     try {
       const deviceTokenObjects = await this.prisma.deviceToken.findMany();
       const deviceTokens = deviceTokenObjects.map((el) => el.deviceToken);
-      const expoPushPayloads = chunkArray(
+      const expoPushPayloads = this.chunkArray(
         MAX_TOKENS_PER_REQUEST,
         deviceTokens,
       ).map((deviceTokenArray) => {
@@ -107,5 +106,14 @@ export class DeviceTokenService {
       },
       body: JSON.stringify(expoPushPayload),
     });
+  }
+
+  private chunkArray<T>(chunkSize: number, array: T[]): T[][] {
+    return Array.from(
+      { length: Math.ceil(array.length / chunkSize) },
+      (_, i) => {
+        return array.slice(i * chunkSize, (i + 1) * chunkSize);
+      },
+    );
   }
 }

--- a/nestJS/src/device-token/device-token.service.ts
+++ b/nestJS/src/device-token/device-token.service.ts
@@ -47,25 +47,19 @@ export class DeviceTokenService {
   async pushNotification(
     pushNotificationInput: PushNotificationInput,
   ): Promise<string> {
-    try {
-      const deviceTokenObjects = await this.prisma.deviceToken.findMany();
-      const deviceTokens = deviceTokenObjects.map((el) => el.deviceToken);
-      const expoPushPayloads = this.chunkArray(
-        MAX_TOKENS_PER_REQUEST,
-        deviceTokens,
-      ).map((deviceTokenArray) => {
-        return this.createExpoPushPayload(
-          pushNotificationInput,
-          deviceTokenArray,
-        );
-      });
-      await Promise.all(expoPushPayloads.map(this.fetchExpoPush));
-      return 'push notification completed';
-    } catch (e) {
-      if (e instanceof PrismaClientKnownRequestError) {
-        throw new BadRequestException();
-      }
-    }
+    const deviceTokenObjects = await this.prisma.deviceToken.findMany();
+    const deviceTokens = deviceTokenObjects.map((el) => el.deviceToken);
+    const expoPushPayloads = this.chunkArray(
+      MAX_TOKENS_PER_REQUEST,
+      deviceTokens,
+    ).map((deviceTokenArray) => {
+      return this.createExpoPushPayload(
+        pushNotificationInput,
+        deviceTokenArray,
+      );
+    });
+    await Promise.all(expoPushPayloads.map(this.fetchExpoPush));
+    return 'push notification completed';
   }
 
   async deleteDeviceToken(

--- a/nestJS/src/device-token/device-token.service.ts
+++ b/nestJS/src/device-token/device-token.service.ts
@@ -9,7 +9,40 @@ import { DeviceTokenCreateInput } from './interface/device-token-create.input';
 import { DeviceTokenDeleteInput } from './interface/device-token-delete.input';
 import { validateValue } from 'src/common/validate-value';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { PushNotificationInput } from './interface/push-notification.input';
+import { ExpoPushPayload } from './interface/expo-push.payload';
+import { chunkArray } from 'src/common/chunkArray';
 
+const chunkStrArr100 = chunkArray<string>(100);
+
+const createExpoPushPayload = (
+  pushNotificationInput: PushNotificationInput,
+  deviceTokens: string[],
+): ExpoPushPayload => {
+  return {
+    to: deviceTokens,
+    title: pushNotificationInput.title,
+    body: pushNotificationInput.message,
+    data: pushNotificationInput.data,
+  };
+};
+
+const fetchExpoPush = async (expoPushPayload: ExpoPushPayload) => {
+  const res = await fetch('https://exp.host/--/api/v2/push/send', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Accept-encoding': 'gzip, deflate',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(expoPushPayload),
+  });
+  console.log(res);
+};
+
+const pickUpDeviceToken = (deviceTokens: DeviceTokenPayload): string => {
+  return deviceTokens.deviceToken;
+};
 @Injectable()
 export class DeviceTokenService {
   constructor(private readonly prisma: CustomPrismaService) {}
@@ -33,6 +66,26 @@ export class DeviceTokenService {
         data: createDeviceToken,
       });
       return 'create completed';
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError) {
+        throw new BadRequestException();
+      }
+    }
+  }
+
+  async pushNotification(
+    pushNotificationInput: PushNotificationInput,
+  ): Promise<string> {
+    try {
+      const deviceTokenObjects = await this.prisma.deviceToken.findMany();
+      const deviceTokens = deviceTokenObjects.map(pickUpDeviceToken);
+      const expoPushPayloads = chunkStrArr100(deviceTokens).map(
+        (deviceTokenArray) => {
+          return createExpoPushPayload(pushNotificationInput, deviceTokenArray);
+        },
+      );
+      await Promise.all(expoPushPayloads.map(fetchExpoPush));
+      return 'push notification completed';
     } catch (e) {
       if (e instanceof PrismaClientKnownRequestError) {
         throw new BadRequestException();

--- a/nestJS/src/device-token/interface/expo-push.payload.ts
+++ b/nestJS/src/device-token/interface/expo-push.payload.ts
@@ -1,0 +1,24 @@
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsInstance,
+  IsNotEmpty,
+  IsString,
+} from 'class-validator';
+
+export class ExpoPushPayload {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsString({ each: true })
+  to: string[];
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+  @IsString()
+  @IsNotEmpty()
+  body: string;
+  @IsInstance(Object)
+  data: { screen: string; params: Object };
+}

--- a/nestJS/src/device-token/interface/push-notification.input.ts
+++ b/nestJS/src/device-token/interface/push-notification.input.ts
@@ -1,0 +1,12 @@
+import { IsInstance, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class PushNotificationInput {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+  @IsString()
+  @IsNotEmpty()
+  message: string;
+  @IsInstance(Object)
+  data: { screen: string; params: Object };
+}


### PR DESCRIPTION
# 目的や背景
履修登録をアルパカ利用者に通知
# 変更内容の概要
dbのデバイストークンを取得しすべてにプッシュ通知を送るエンドポイントの作成。
関数型っぽくした。
# スクリーンショット

# 関連するリンク

# Staging 環境での動作確認チェックリスト

- [ ] ここに確認事項を記載
